### PR TITLE
TexView, File position, scrolling, etc

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -135,7 +135,8 @@ impl Motex {
             self.sample32_tex.width = 32;
             self.sample32_tex.height = 32;
 
-            self.sample32_tex.draw(&self.file.data, self.file_pos, ui);
+            self.sample32_tex
+                .draw(&self.file.data, self.file_pos, ui, ctx);
         });
     }
 
@@ -170,12 +171,12 @@ impl Motex {
             .resizable(false)
             .show(ctx, |ui| {
                 ui.vertical_centered(|ui| {
-                    self.render_right_panel_content(ui);
+                    self.render_right_panel_content(ui, ctx);
                 });
             });
     }
 
-    fn render_right_panel_content(&mut self, ui: &mut egui::Ui) {
+    fn render_right_panel_content(&mut self, ui: &mut egui::Ui, ctx: &egui::Context) {
         if self.file.data.is_empty() {
             ui.label("No image data to display");
             return;
@@ -188,7 +189,8 @@ impl Motex {
         self.preview_tex.width = 128;
         self.preview_tex.height = ui.available_height() as usize - 5;
 
-        self.preview_tex.draw(&self.file.data, self.file_pos, ui);
+        self.preview_tex
+            .draw(&self.file.data, self.file_pos, ui, ctx);
     }
 
     /// Opens the About window and renders the contents of the window

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,0 @@
-// src/lib.rs
-
-pub mod files;
-
-// Re-export items for convenient access
-pub use files::bin_handler::BinFile;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 mod app;
 mod files;
+mod texview;
 
 use app::Motex;
 

--- a/src/texview.rs
+++ b/src/texview.rs
@@ -1,0 +1,110 @@
+use std::iter;
+
+use eframe::egui::{self, Color32, ColorImage, Image, TextureHandle, TextureOptions};
+use pigment64::{ImageType, NativeImage};
+
+pub struct TexView {
+    pub format: ImageType,
+    pub width: usize,
+    pub height: usize,
+    pub bg_color: Color32,
+    pub bg_tex: TextureHandle,
+    pub tex: TextureHandle,
+}
+
+impl TexView {
+    pub fn create(cc: &eframe::CreationContext<'_>, tex_name: &str) -> TexView {
+        TexView {
+            format: ImageType::I8,
+            width: 0,
+            height: 0,
+            bg_color: Color32::from_rgba_premultiplied(0, 0, 0, 255),
+            bg_tex: cc.egui_ctx.load_texture(
+                tex_name.to_owned() + "_bg",
+                egui::ColorImage::new([1, 1], egui::Color32::WHITE),
+                Default::default(),
+            ),
+            tex: cc.egui_ctx.load_texture(
+                tex_name,
+                egui::ColorImage::new([1, 1], egui::Color32::WHITE),
+                Default::default(),
+            ),
+        }
+    }
+    /// Draw the texture with the given data.
+    pub fn draw(&mut self, data: &[u8], offset: usize, ui: &mut egui::Ui) {
+        if offset > data.len() {
+            return;
+        }
+
+        let siz: usize = self.width * self.height * 4;
+
+        // Create a black background
+        let bg_data: Vec<u8> = std::iter::repeat(self.bg_color.to_array())
+            .flatten()
+            .take(siz)
+            .collect();
+        self.bg_tex.set(
+            data_to_color_image(self.width, self.height, bg_data.as_slice()),
+            TextureOptions::LINEAR,
+        );
+
+        // Draw bg and save rect for actual texture location
+        let bg_loc = ui.image(&self.bg_tex);
+
+        let ni: NativeImage = NativeImage::read(
+            &data[offset..],
+            self.format,
+            self.width as u32,
+            self.height as u32,
+        )
+        .unwrap();
+
+        let mut decoded_data: Vec<u8> = vec![];
+        let _ = ni.decode(&mut decoded_data, None);
+
+        let img_data = pad_to_length(decoded_data, siz);
+        let img = data_to_color_image(self.width, self.height, img_data.as_slice());
+        self.tex.set(img, TextureOptions::LINEAR);
+
+        // Put the texture directly over the background
+        ui.put(bg_loc.rect, Image::new(&self.tex));
+    }
+}
+
+// TODO this can probably be implemented better and avoid allocating a Vec or something
+pub fn pad_to_length(data: Vec<u8>, length: usize) -> Vec<u8> {
+    match data.len() < length {
+        true => {
+            let mut ret: Vec<u8> = data.clone();
+            ret.extend(iter::repeat(0).take(length - data.len()));
+
+            ret
+        }
+        false => data[..length].to_vec(),
+    }
+}
+
+/// Convert raw RGBA data to a `ColorImage`, adjusting the color values for color accuracy.
+pub fn data_to_color_image(width: usize, height: usize, data: &[u8]) -> ColorImage {
+    ColorImage {
+        pixels: {
+            data.chunks_exact(4)
+                .map(|p| {
+                    let r = p[0] as u32;
+                    let g = p[1] as u32;
+                    let b = p[2] as u32;
+                    let a = p[3] as u32;
+
+                    Color32::from_rgba_premultiplied(
+                        ((r * a + 128) / 256) as u8,
+                        ((g * a + 128) / 256) as u8,
+                        ((b * a + 128) / 256) as u8,
+                        a as u8,
+                    )
+                })
+                .collect()
+        },
+        size: [width, height],
+    }
+}

--- a/src/texview.rs
+++ b/src/texview.rs
@@ -32,7 +32,7 @@ impl TexView {
         }
     }
     /// Draw the texture with the given data.
-    pub fn draw(&mut self, data: &[u8], offset: usize, ui: &mut egui::Ui) {
+    pub fn draw(&mut self, data: &[u8], offset: usize, ui: &mut egui::Ui, ctx: &egui::Context) {
         if offset > data.len() {
             return;
         }
@@ -68,7 +68,19 @@ impl TexView {
         self.tex.set(img, TextureOptions::LINEAR);
 
         // Put the texture directly over the background
-        ui.put(bg_loc.rect, Image::new(&self.tex));
+        let res = ui.put(bg_loc.rect, Image::new(&self.tex));
+
+        let tex_rect = res.rect;
+
+        if let Some(cursor_pos) = ctx.input(|i| i.pointer.hover_pos()) {
+            if tex_rect.contains(cursor_pos) {
+                let relative_pos = cursor_pos - tex_rect.min;
+                let pixel = relative_pos.y * self.width as f32 + relative_pos.x;
+                // get index into data from pixel
+                let index = (pixel as usize) * 4;
+                // somethin else TODO
+            }
+        }
     }
 }
 


### PR DESCRIPTION
I tried to keep this concise, but I ended up touching practically everything...oopsh.

**New features:**
* Abstracted a texture we render onto the screen into a TexView struct with a draw method for drawing said texture with the given data (all in its own texview.rs file with useful methods attached). Now every texture we draw will have a background of arbitrary color (defaults to black currently) and correct color calculations from #6 
* Added the notion of our current file position, which is used to influence the texture decoding / rendering and is displayed above the preview on the right
  * Added scrolling support to modify the file position. The implementation of this is kind of opinionated, and I am not sure I like it, but I can explain why I did it the way I did sometime
* Added support for loading a file by dropping it onto the motex window (copied cod from bdiff for this)

**Cleanuppy changes that I would argue are better but are still subjective to some degree:**
* Store just a plain `BinFile` onto the main struct instead of breaking it into its fields and storing those separately
* When we load a file, we don't automatically decode it with pigment64 - we now wait until rendering to do that

**More subjective changes that I'm happy to revert if you prefer:**
* Made the right panel a bit skinner to just accommodate the preview
* Have the file size next to the path in the bottom bar as opposed to at the top of the right panel (and update comments accordingly)


Resolves #1